### PR TITLE
fix: add check for Docker secrets availability in GitHub Actions work…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,12 @@ jobs:
         run: |
           VERSION=$(grep -oP '(?<=<Version>)(.*)(?=</Version>)' **/*.csproj)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      # Check if the Docker image with the version already exists on Docker Hub
+      - name: Check if secrets are available
+        run: |
+          echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}"
+          echo "DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD }}"
+          
+          # Check if the Docker image with the version already exists on Docker Hub
       - name: Check if Docker Image Exists on Docker Hub
         id: check_image_exists
         run: |
@@ -66,6 +70,6 @@ jobs:
       # Push Images to Docker Hub
       - name: Push Frontend Image
         run: docker push ${{ secrets.DOCKER_USERNAME }}/blazor-frontend:${{ env.VERSION }}
- 
+
       - name: Push Backend Image
         run: docker push ${{ secrets.DOCKER_USERNAME }}/blazor-backend:${{ env.VERSION }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/build.yaml` file to add a step for checking the availability of Docker secrets.

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R41-R44): Added a new step to check if `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are available in the environment.